### PR TITLE
add JSON_NUMERIC_CHECK to encoding options

### DIFF
--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -56,7 +56,7 @@ class JSONFormatter implements FormatterInterface
 	 */
 	public function format($data)
 	{
-		$options = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR;
+		$options = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_NUMERIC_CHECK;
 
 		$options = ENVIRONMENT === 'production' ? $options : $options | JSON_PRETTY_PRINT;
 


### PR DESCRIPTION
**Description**
Add JSON_NUMERIC_CHECK to encoding options to make numeric values more correct type in json receive part.
It might be a better option to have this configurable or have a config value that can add to this if need be in future maybe ?

Each pull request should address a single issue and have a meaningful title.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
